### PR TITLE
Update matchdayschedule and standings views to fit 8 teams

### DIFF
--- a/src/style/themes/sgl/_matchdaySchedule.scss
+++ b/src/style/themes/sgl/_matchdaySchedule.scss
@@ -55,7 +55,7 @@
 
 	.tier {
 		position: absolute;
-		top: 200px;
+		top: 150px;
 		width: 650px;
 
 		.tierName {
@@ -76,10 +76,6 @@
 				letter-spacing: .1em;
 			}
 
-		}
-
-		.tierMatches {
-			height: 100vh;
 		}
 
 		&:nth-child(1) {

--- a/src/style/themes/sgl/_matchdaySchedule.scss
+++ b/src/style/themes/sgl/_matchdaySchedule.scss
@@ -78,6 +78,10 @@
 
 		}
 
+		.tierMatches {
+			height: 100vh;
+		}
+
 		&:nth-child(1) {
 			left: 185px;
 

--- a/src/style/themes/sgl/_standings.scss
+++ b/src/style/themes/sgl/_standings.scss
@@ -43,7 +43,7 @@
 		--tierBackground: #{variables.$backgroundColor};
 
 		position: absolute;
-		top: 190px;
+		top: 160px;
 		width: 750px;
 
 		&:nth-child(1) {

--- a/src/style/themes/sgl/variables.scss
+++ b/src/style/themes/sgl/variables.scss
@@ -63,7 +63,7 @@ $playerBoxBoostTextWidth: 44px;
 $playerBoxBoostBarSize: $borderSize;
 $playerBoxEventSize: 24px;
 
-$scheduleTeamLogoWidth: 80px;
+$scheduleTeamLogoWidth: 65px;
 $scheduleTeamBoxMargin: .04;
 $scheduleScoreWidth: 100px;
 

--- a/src/views/overlay/Overlay.jsx
+++ b/src/views/overlay/Overlay.jsx
@@ -20,8 +20,8 @@ import { v4 as uuidv4 } from "uuid";
 const expireEventsInMs = 7000;
 const gameSocketUrl = "ws://localhost:49122";
 
-//const socketServerUrl = "wss://rl.kdoughboy.com/ws/"; // prod
-const socketServerUrl = "ws://localhost:8321"; // local testing
+const socketServerUrl = "wss://rl.kdoughboy.com/ws/"; // prod
+//const socketServerUrl = "ws://localhost:8321"; // local testing
 
 const Overlay = () => {
 

--- a/src/views/overlay/Overlay.jsx
+++ b/src/views/overlay/Overlay.jsx
@@ -20,8 +20,8 @@ import { v4 as uuidv4 } from "uuid";
 const expireEventsInMs = 7000;
 const gameSocketUrl = "ws://localhost:49122";
 
-const socketServerUrl = "wss://rl.kdoughboy.com/ws/"; // prod
-// const socketServerUrl = "ws://localhost:8321"; // local testing
+//const socketServerUrl = "wss://rl.kdoughboy.com/ws/"; // prod
+const socketServerUrl = "ws://localhost:8321"; // local testing
 
 const Overlay = () => {
 


### PR DESCRIPTION
Currently, the schedule and standings views only fit up to 7 teams (6 teams in schedule, 7 team in standings). After adding an 8th team into a division, the views are unable to properly show all 8 teams. To fix this, the top padding for both schedule and standings views as well as the logo size have been reduced.